### PR TITLE
Allow `let` statements to be used in `if` blocks

### DIFF
--- a/ngx_http_let_module.c
+++ b/ngx_http_let_module.c
@@ -46,7 +46,7 @@ static char* ngx_http_let_let(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static ngx_command_t ngx_http_let_commands[] = {
 
 	{	ngx_string("let"),
-		NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+		NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_1MORE,
 		ngx_http_let_let,
 		NGX_HTTP_LOC_CONF_OFFSET,
 		0,


### PR DESCRIPTION
Example config with `let` statement used in an `if` block:

```
  location /lettest {
    let $counter_in_location $http_x_counter + 1;

    if ($counter_in_location) {
      let $counter_in_if $counter_in_location + 1;
    }

    return 200 "Initial: $http_x_counter\nLocation: $counter_in_location\nIf: $counter_in_if\n\n";
  }
```

Example output:

```
$ curl -H "X-Counter: 1" http://localhost/lettest
Initial: 1
Location: 2
If: 3
```
